### PR TITLE
fix: entire data parser failing when the hourly forecast isn't available

### DIFF
--- a/Parse.js
+++ b/Parse.js
@@ -128,11 +128,15 @@ class Parse {
     });
     result.regionalNormals = result.forecastGroup.regionalNormals;
     delete result.forecastGroup;
-    result.hourlyForecastGroup.hourlyForecast.forEach(el => {
-      const copy = { ...el };
-      delete copy.dateTimeUTC;
-      forecast.set(el.dateTimeUTC, copy);
-    });
+    const hourlyForecastGroup = result.hourlyForecastGroup;
+    if (hourlyForecastGroup) {
+      hourlyForecastGroup.hourlyForecast.forEach((el) => {
+        const copy = { ...el };
+        delete copy.dateTimeUTC;
+        forecast.set(el.dateTimeUTC, copy);
+      });
+      delete result.hourlyForecastGroup;
+    }
     delete result.hourlyForecastGroup;
     result.forecast = forecast;
     return new Parse(result);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ec-weather-js",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "description": "JavaScript API for Environment Canada Weather Data",
   "main": "Weather.js",
   "scripts": {


### PR DESCRIPTION
No idea why but it looks like there's no `hourlyForecastGroup` data available to us currently. This will stop the entire parser falling over if this is the case.

```
<forecastGroup>
...
</forecastGroup>
<hourlyForecastGroup/>
<yesterdayConditions>
...
</yesterdayConditions>
```